### PR TITLE
Pass dimensions to freemarker as strings

### DIFF
--- a/src/integration-test/java/de/monticore/lang/monticar/generator/JsGeneratorIT.java
+++ b/src/integration-test/java/de/monticore/lang/monticar/generator/JsGeneratorIT.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-public class JsGeneratorIT {
+class JsGeneratorIT {
 
   private static final Path RESSOURCE_DIR = Paths
       .get("src/integration-test/resources/jsfilegeneration");
@@ -52,7 +52,7 @@ public class JsGeneratorIT {
 
   @ParameterizedTest
   @ValueSource(strings = {
-      "noPorts", "caretSymbol",
+      "noPorts", "caretSymbol", "thousandsDimension",
       "scalar_NoRangeNoUnit", "scalar_RangeNoUnit", "scalar_RangeUnit",
       "array_NoRangeNoUnit", "array_RangeNoUnit", "array_RangeUnit",
       "rowVector_NoRangeNoUnit", "rowVector_RangeNoUnit", "rowVector_RangeUnit",

--- a/src/integration-test/resources/jsfilegeneration/expected/thousandsDimension.js
+++ b/src/integration-test/resources/jsfilegeneration/expected/thousandsDimension.js
@@ -1,0 +1,61 @@
+var Module = {
+    'print': function (text) {
+        console.log('stdout: ' + text)
+    },
+    'printErr': function (text) {
+        console.log('stderr: ' + text)
+    },
+    onRuntimeInitialized: function () {
+        Module.init();
+    }
+};
+
+function execute() {
+    Module.execute();
+}
+
+function getOutThousandsMatrixArray() {
+    return math.format(Module.getOutThousandsMatrixArray(), {notation: 'fixed'}).concat(" m");
+}
+
+function setInThousandsMatrixArray(_inThousandsMatrixArray) {
+    var value = math.eval(_inThousandsMatrixArray);
+
+    if (value === undefined) {
+        throw "Could not evaluate input for _inThousandsMatrixArray";
+    }
+
+    //check dimension
+    var dim = math.matrix([1111, 1234, 3, 1200300]);
+    if (!math.deepEqual(value.size(), dim)) {
+        throw "Input has dimension " + value.size() + " but expected " + dim;
+    }
+
+    var array = [];
+    for (var i0 = 0; i0 < 1111; i0++) {
+        array[i0] = [];
+        for (var i1 = 0; i1 < 1234; i1++) {
+            array[i0][i1] = [];
+            for (var i2 = 0; i2 < 3; i2++) {
+                array[i0][i1][i2] = [];
+                for (var i3 = 0; i3 < 1200300; i3++) {
+                    var e = value.get([i0, i1, i2, i3]);
+
+                    //check unit
+                    var expectedUnit = math.eval("m");
+                    if (math.typeof(expectedUnit) !== math.typeof(e) || !expectedUnit.equalBase(e)) {
+                        throw "Expected unit m";
+                    }
+                    var e_num = e.toSI().toNumber();
+                    //check range
+                    if (math.smaller(e_num, 2 / 1)) {
+                        throw "Value " + e_num + " out of range";
+                    }
+                    array[i0][i1][i2][i3] = e_num;
+                }
+            }
+        }
+    }
+    Module.setInThousandsMatrixArray(array);
+}
+

--- a/src/integration-test/resources/jsfilegeneration/models/ThousandsDimension.emam
+++ b/src/integration-test/resources/jsfilegeneration/models/ThousandsDimension.emam
@@ -1,0 +1,7 @@
+package models;
+
+component ThousandsDimension {
+  ports
+    in Q(2 m: oo m)^{1234, 3, 1200300} inThousandsMatrixArray[1111],
+    out Q(-oo m : oo m)^{1234, 3, 1200300} outThousandsMatrixArray[1111];
+}

--- a/src/main/java/de/monticore/lang/monticar/generator/js/JsGenerator.java
+++ b/src/main/java/de/monticore/lang/monticar/generator/js/JsGenerator.java
@@ -69,23 +69,23 @@ public class JsGenerator {
   }
 
   @VisibleForTesting
-  static int[] getDimension(Collection<PortSymbol> ports, PortSymbol port) {
+  static String[] getDimension(Collection<PortSymbol> ports, PortSymbol port) {
     int arrayDimension = port.isPartOfPortArray() ?
         getArrayDimension(ports, port.getNameWithoutArrayBracketPart()) : 0;
     int[] matrixDimension = getMatrixDimension(port);
     return combineDimensions(arrayDimension, matrixDimension);
   }
 
-  private static int[] combineDimensions(int arrayDimension, int[] matrixDimension) {
+  private static String[] combineDimensions(int arrayDimension, int[] matrixDimension) {
     if (arrayDimension > 0 && matrixDimension.length > 0) {
       int[] dimension = new int[matrixDimension.length + 1];
       dimension[0] = arrayDimension;
       System.arraycopy(matrixDimension, 0, dimension, 1, matrixDimension.length);
-      return dimension;
+      return toStringArray(dimension);
     } else if (matrixDimension.length > 0) {
-      return matrixDimension;
+      return toStringArray(matrixDimension);
     } else if (arrayDimension > 0) {
-      return new int[]{arrayDimension};
+      return new String[]{String.valueOf(arrayDimension)};
     } else {
       return null;
     }
@@ -138,6 +138,10 @@ public class JsGenerator {
 
   private static String join(String delimiter, String... elements) {
     return Arrays.stream(elements).filter(s -> !s.isEmpty()).collect(Collectors.joining(delimiter));
+  }
+
+  private static <T> String[] toStringArray(int[] array) {
+    return Arrays.stream(array).mapToObj(String::valueOf).toArray(String[]::new);
   }
 
   private static String format(Unit<?> unit) {

--- a/src/main/java/de/monticore/lang/monticar/generator/js/Setter.java
+++ b/src/main/java/de/monticore/lang/monticar/generator/js/Setter.java
@@ -5,7 +5,7 @@ public class Setter {
   private String methodName;
   private String parameterName;
   private String delegateMethodName;
-  private int[] dimension;
+  private String[] dimension;
   private String lowerBoundValue;
   private String lowerBoundUnit;
   private String upperBoundValue;
@@ -35,11 +35,11 @@ public class Setter {
     this.delegateMethodName = delegateMethodName;
   }
 
-  public int[] getDimension() {
+  public String[] getDimension() {
     return dimension;
   }
 
-  public void setDimension(int[] dimension) {
+  public void setDimension(String[] dimension) {
     this.dimension = dimension;
   }
 

--- a/src/test/java/de/monticore/lang/monticar/generator/js/JsGeneratorTest.java
+++ b/src/test/java/de/monticore/lang/monticar/generator/js/JsGeneratorTest.java
@@ -28,14 +28,6 @@ class JsGeneratorTest {
   private static final String OUT = "out";
 
   private static final String RANGE_MODEL = "models.multiplePorts";
-  private static final String BOOL = "Bool";
-  private static final String UNBOUNDED = "Unbounded";
-  private static final String BOUNDED = "Bounded";
-  private static final String STEP = "Step";
-  private static final String UNIT = "Unit";
-  private static final String UPPER_BOUND = "UpperBound";
-  private static final String LOWER_BOUND = "LowerBound";
-  private static final String STEP_UNIT = "StepUnit";
 
   private static final String DIMENSION_MODEL = "models.dimensions";
   private static final String SCALAR = "Scalar";
@@ -131,7 +123,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getIncomingPort(portName(IN, ARRAY)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(3);
+          assertThat(getDimension(ports, port)).containsExactly("3");
         }
 
         @Test
@@ -139,7 +131,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getIncomingPort(portName(IN, ROW_VECTOR)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(1, 3);
+          assertThat(getDimension(ports, port)).containsExactly("1", "3");
         }
 
         @Test
@@ -147,7 +139,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getIncomingPort(portName(IN, COLUMN_VECTOR)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(4, 1);
+          assertThat(getDimension(ports, port)).containsExactly("4", "1");
         }
 
         @Test
@@ -155,7 +147,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getIncomingPort(portName(IN, MATRIX)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(2, 3);
+          assertThat(getDimension(ports, port)).containsExactly("2", "3");
         }
 
         @Test
@@ -163,7 +155,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getIncomingPort(portName(IN, MATRIX_ARRAY)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(2, 3, 4);
+          assertThat(getDimension(ports, port)).containsExactly("2", "3", "4");
         }
       }
 
@@ -175,7 +167,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getOutgoingPort(portName(OUT, ARRAY)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(3);
+          assertThat(getDimension(ports, port)).containsExactly("3");
         }
 
         @Test
@@ -183,7 +175,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getOutgoingPort(portName(OUT, ROW_VECTOR)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(1, 3);
+          assertThat(getDimension(ports, port)).containsExactly("1", "3");
         }
 
         @Test
@@ -191,7 +183,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getOutgoingPort(portName(OUT, COLUMN_VECTOR)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(4, 1);
+          assertThat(getDimension(ports, port)).containsExactly("4", "1");
         }
 
         @Test
@@ -199,7 +191,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getOutgoingPort(portName(OUT, MATRIX)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(2, 3);
+          assertThat(getDimension(ports, port)).containsExactly("2", "3");
         }
 
         @Test
@@ -207,7 +199,7 @@ class JsGeneratorTest {
           Collection<PortSymbol> ports = dimensionModel.getPorts();
           PortSymbol port = dimensionModel.getOutgoingPort(portName(OUT, MATRIX_ARRAY)).get();
 
-          assertThat(getDimension(ports, port)).containsExactly(2, 3, 4);
+          assertThat(getDimension(ports, port)).containsExactly("2", "3", "4");
         }
       }
     }


### PR DESCRIPTION
Generally, Freemarker prints a localized representation of int passed
to it. This leads to errors in Javascript later on, if a number was
printed including decimal separators (e.g. 1,000,000).